### PR TITLE
Various Bugfixes to make it running

### DIFF
--- a/incubator/zookeeper/templates/config-script.yaml
+++ b/incubator/zookeeper/templates/config-script.yaml
@@ -22,13 +22,13 @@ data:
       #!/bin/bash
 
       set -a
-      ROOT=$(echo /zook*)
+      ROOT=$(echo /apache-zookeeper-*)
 
       ZK_USER=${ZK_USER:-"zookeeper"}
       ZK_LOG_LEVEL=${ZK_LOG_LEVEL:-"INFO"}
       ZK_DATA_DIR=${ZK_DATA_DIR:-"/data"}
       ZK_DATA_LOG_DIR=${ZK_DATA_LOG_DIR:-"/data/log"}
-      ZK_CONF_DIR=${ZK_CONF_DIR:-"$ROOT/conf"}
+      ZK_CONF_DIR=${ZK_CONF_DIR:-"/conf"}
       ZK_CLIENT_PORT=${ZK_CLIENT_PORT:-2181}
       ZK_SERVER_PORT=${ZK_SERVER_PORT:-2888}
       ZK_ELECTION_PORT=${ZK_ELECTION_PORT:-3888}


### PR DESCRIPTION
`ROOT=$(echo /zook*)`
must be
`ROOT=$(echo /apache-zookeeper-*)`
because the zookeeper dockerimage put the application there.

`ZK_CONF_DIR=${ZK_CONF_DIR:-"$ROOT/conf"}`
must be
`ZK_CONF_DIR=${ZK_CONF_DIR:-"/conf"}`
because there is already a "/conf" with files from the zookeeper dockerimage.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/donbowman/charts/1)
<!-- Reviewable:end -->
