### PR TITLE
Various Bugfixes to make it running

### DIFF
--- a/incubator/zookeeper/templates/statefulset.yaml
+++ b/incubator/zookeeper/templates/statefulset.yaml
@@ -191,6 +191,7 @@ spec:
         - name: config
           configMap:
             name: {{ template "zookeeper.fullname" . }}
+            defaultMode: 0555
         {{- range .Values.secrets }}
         - name: {{ $.Release.Name }}-{{ .name }}
           secret:


### PR DESCRIPTION
The configmap must be mounted with read *and* executing permissions  for every user (and the group), because by default it is owned by *root* and the executing user is *zookeeper*, resulting in a permission denied.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/donbowman/charts/2)
<!-- Reviewable:end -->
